### PR TITLE
Fix typo:timestamp instead of timestamps in Update 2014_10_12_100000_create_password_resets_table.php

### DIFF
--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -16,7 +16,7 @@ class CreatePasswordResetsTable extends Migration
             $table->engine = "InnoDB";
             $table->string('email')->index();
             $table->string('token')->index();
-            $table->timestamps('created_at');
+            $table->timestamp('created_at');
         });
     }
 


### PR DESCRIPTION
When typing `php artisan migration` it was leading to an sql syntax error
